### PR TITLE
Update `superduper-io/superduper` references

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -250,12 +250,12 @@ const sidebars = {
         {
           type: 'link',
           label: 'Change log',
-          href: 'https://raw.githubusercontent.com/superduper.io/superduper/main/CHANGELOG.md',
+          href: 'https://raw.githubusercontent.com/superduper-io/superduper/main/CHANGELOG.md',
         },
         {
           type: 'link',
           label: 'Source on GitHub',
-          href: 'https://github.com/superduper.io/superduper',
+          href: 'https://github.com/superduper-io/superduper',
         },
       ],
     },


### PR DESCRIPTION
## Description

PR fixes the `superduper-io/superduper` references in `sidebars.js`.

## Related Issues

## Checklist

- [ ] Is this code covered by new or existing unit tests or integration tests?
- [ ] Did you run `make unit_testing` and `make integration-testing` successfully?
- [ ] Do new classes, functions, methods and parameters all have docstrings?
- [ ] Were existing docstrings updated, if necessary?
- [ ] Was external documentation updated, if necessary?


## Additional Notes or Comments
